### PR TITLE
Addition: rooster to makefile (part 1)

### DIFF
--- a/.rooster.yaml
+++ b/.rooster.yaml
@@ -3,69 +3,69 @@
   extensions:
     - ods
     - "*.x*"
-  out: rooster_out/apache_spreadsheet
+  out: apache_spreadsheet
 - repo: https://github.com/python-excel/xlrd
   type: git
   extensions:
     - ods
     - "*.x*"
-  out: rooster_out/python-excel_xlrd
+  out: python-excel_xlrd
 - repo: https://github.com/jmcnamara/excel-reader-xlsx
   type: git
   extensions:
     - ods
     - "*.x*"
-  out: rooster_out/jmcnamara_excel-reader-xlsx
+  out: jmcnamara_excel-reader-xlsx
 - repo: https://github.com/WoLpH/pyExcelerator
   type: git
   extensions:
     - ods
     - "*.x*"
-  out: rooster_out/WoLpH_pyExcelerator
+  out: WoLpH_pyExcelerator
 - repo: https://github.com/SheetJS/jxls
   type: git
   extensions:
     - ods
     - "*.x*"
-  out: rooster_out/SheetJS_jxls
+  out: SheetJS_jxls
 - repo: https://github.com/Empact/roo
   type: git
   extensions:
     - ods
     - "*.x*"
-  out: rooster_out/Empact_roo
+  out: Empact_roo
 - repo: https://github.com/roo-rb/roo-xls
   type: git
   extensions:
     - ods
     - "*.x*"
-  out: rooster_out/roo-rb_roo-xls
+  out: roo-rb_roo-xls
 - repo: https://github.com/doy/spreadsheet-parsexlsx
   type: git
   extensions:
     - ods
     - "*.x*"
-  out: rooster_out/doy_spreadsheet-parsexlsx
+  out: doy_spreadsheet-parsexlsx
 - repo: https://github.com/box/spout
   type: git
   extensions:
     - ods
     - "*.x*"
-  out: rooster_out/box_spout
+  out: box_spout
 - repo: git://github.com/SheetJS/libreoffice_test-files
   type: git
   extensions:
     - ods
     - "*.x*"
-  out: rooster_out/SheetJS_libreoffice_test-files
+  out: SheetJS_libreoffice_test-files
 - repo: https://svn.apache.org/repos/asf/openoffice/branches/AOO34/main/testautomation/xml/optional/input/calc/ExcelXML
   type: svn
   extensions:
     - ods
     - "*.x*"
-  out: rooster_out/apache_ExcelXML
+  out: apache_ExcelXML
 - repo: https://foss.heptapod.net/openpyxl/openpyxl
   type: hg
   extensions:
     - "*.xls*"
-  out: rooster_out/openpyxl_openpyxl
+  out: openpyxl_openpyxl

--- a/.rooster.yaml
+++ b/.rooster.yaml
@@ -1,0 +1,71 @@
+- repo: http://svn.apache.org/repos/asf/poi/trunk/test-data/spreadsheet
+  type: svn
+  extensions:
+    - ods
+    - "*.x*"
+  out: rooster_out/apache_spreadsheet
+- repo: https://github.com/python-excel/xlrd
+  type: git
+  extensions:
+    - ods
+    - "*.x*"
+  out: rooster_out/python-excel_xlrd
+- repo: https://github.com/jmcnamara/excel-reader-xlsx
+  type: git
+  extensions:
+    - ods
+    - "*.x*"
+  out: rooster_out/jmcnamara_excel-reader-xlsx
+- repo: https://github.com/WoLpH/pyExcelerator
+  type: git
+  extensions:
+    - ods
+    - "*.x*"
+  out: rooster_out/WoLpH_pyExcelerator
+- repo: https://github.com/SheetJS/jxls
+  type: git
+  extensions:
+    - ods
+    - "*.x*"
+  out: rooster_out/SheetJS_jxls
+- repo: https://github.com/Empact/roo
+  type: git
+  extensions:
+    - ods
+    - "*.x*"
+  out: rooster_out/Empact_roo
+- repo: https://github.com/roo-rb/roo-xls
+  type: git
+  extensions:
+    - ods
+    - "*.x*"
+  out: rooster_out/roo-rb_roo-xls
+- repo: https://github.com/doy/spreadsheet-parsexlsx
+  type: git
+  extensions:
+    - ods
+    - "*.x*"
+  out: rooster_out/doy_spreadsheet-parsexlsx
+- repo: https://github.com/box/spout
+  type: git
+  extensions:
+    - ods
+    - "*.x*"
+  out: rooster_out/box_spout
+- repo: git://github.com/SheetJS/libreoffice_test-files
+  type: git
+  extensions:
+    - ods
+    - "*.x*"
+  out: rooster_out/SheetJS_libreoffice_test-files
+- repo: https://svn.apache.org/repos/asf/openoffice/branches/AOO34/main/testautomation/xml/optional/input/calc/ExcelXML
+  type: svn
+  extensions:
+    - ods
+    - "*.x*"
+  out: rooster_out/apache_ExcelXML
+- repo: https://foss.heptapod.net/openpyxl/openpyxl
+  type: hg
+  extensions:
+    - "*.xls*"
+  out: rooster_out/openpyxl_openpyxl

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,15 @@ github = $(GSVN) https://github.com/$(1)/trunk/$(2) $@; $(CPUP)
 ## Make Targets
 
 .PHONY: init clean
-init: all ## Entry Point (init)
+init: rooster ## Entry Point (init)
+
+.PHONY: rooster
+rooster: .rooster.yaml
+	rooster -config $<
+
+.PHONY: rooster-clean
+rooster-clean:
+	rm -rf rooster_out
 
 .PHONY: all
 all: svn hg git ## All files

--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,6 @@ init: rooster ## Entry Point (init)
 rooster: .rooster.yaml
 	rooster -config $<
 
-.PHONY: rooster-clean
-rooster-clean:
-	rm -rf rooster_out
-
 .PHONY: all
 all: svn hg git ## All files
 


### PR DESCRIPTION
This adds rooster and a rooster-clean target to the Makefile.
It also uses rooster as the init target.
This commit also addresses all the remote repos in the `.rooster.yaml` file.

This commit should close #9.